### PR TITLE
Add deployment badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Frontend Technology Study Workspace
 
+[![Deploy](https://github.com/madelk/learning/actions/workflows/deploy.yml/badge.svg)](https://github.com/madelk/learning/actions/workflows/deploy.yml)
+
 This monorepo contains multiple frontend applications built with different frameworks, managed using Nx. It serves as a study and comparison environment for various frontend technologies.
 
 ## Project Structure


### PR DESCRIPTION
Include a deployment badge in the README to provide visibility into the deployment status of the project.